### PR TITLE
Bugfix for countries with no name.

### DIFF
--- a/api_libraries/earthempires.py
+++ b/api_libraries/earthempires.py
@@ -54,6 +54,8 @@ def clan_land(df):
 
 def player_land(df):
     df.columns = ["Number", "Country", "Land", "Clan"]
+    # Fill empty country names with the player number.
+    df["Country"].fillna(df["Number"].astype(str), inplace=True)
     total_land_per_player = df.groupby("Country")["Land"].sum().reset_index()
     total_land_per_player_sorted = total_land_per_player.sort_values(
         by="Land", ascending=False


### PR DESCRIPTION
Initially, countries with no name were getting skipped over. After fixing that, I discovered it was merging those no name countries into one row. So I renamed each blank country with their unique number.